### PR TITLE
Link to ROSE initiative

### DIFF
--- a/department-of-reuse/src/components/Navigation.vue
+++ b/department-of-reuse/src/components/Navigation.vue
@@ -7,7 +7,7 @@
             <a class="hover:bg-blue-400 px-1" href="https://github.com/bhermann/DoR">Source code</a>
             <!-- <a class="hover:bg-blue-400 px-1" href="https://github.com/bhermann/DoR">Meet the team</a> -->
         </div>
-        <div class="flex-none">The Department of Reuse is a department within the ROSE initiative.</div>
+        <div class="flex-none">The Department of Reuse is a department within the <a href="https://global.rutgers.edu/rose>ROSE initiative</a>.</div>
     </div>
 </template>
 <script lang="ts">


### PR DESCRIPTION
Browsing the page, I stumbled upon this text bit:
![image](https://user-images.githubusercontent.com/15788906/151843876-c1a7ec19-e89f-4d0d-adb9-76dc4368fa00.png)

I'm not sure which ROSE initiative you are referring to, so I suggest adding a link to the correct one. This PR includes my best guess.
