### PR TITLE
Add indicator for when no reuse data is available for a paper

### DIFF
--- a/department-of-reuse/src/pages/Paper.vue
+++ b/department-of-reuse/src/pages/Paper.vue
@@ -61,7 +61,11 @@
         <div>
           <h2 class="text-l bg-opacity-40 bg-blue-200">Reusing</h2>
 
-          <table class="text-left">
+          <div v-if="paperNotInIndex" class="text-center p-5">
+            <span class="border-2 border-black rounded-lg text-lg p-2 border-gray-400"> No Reuse Data in Index </span>
+          </div>
+          <div v-else>
+            <table class="text-left">
               <tr>
                 <th>Identifier</th>
                 <th>Title</th>
@@ -103,6 +107,10 @@
             </tr>
           </table>
 
+          </div>
+
+          
+
         </div>
       </div>
     </div>
@@ -137,6 +145,7 @@ export default defineComponent({
     const paper = ref({} as WorkMessage);
     const reusedStuff = ref(new Array<ReuseLine>());
     const reusingStuff = ref(new Array<ReuseLine>());
+    const paperNotInIndex = ref(true);
 
     const doi = ref("");
 
@@ -211,6 +220,8 @@ export default defineComponent({
 
         reusingStuff.value = await resolveDois(reusingStuff.value);
 
+      paperNotInIndex.value = (reusingStuff.value.length === 0);
+
       isLoading.value = false;
     }
 
@@ -230,7 +241,7 @@ export default defineComponent({
       return reuse;
     }
 
-    return { paper, reusedStuff, reusingStuff, isLoading, reuseData, doi };
+    return { paper, paperNotInIndex, reusedStuff, reusingStuff, isLoading, reuseData, doi };
   },
 });
 </script>


### PR DESCRIPTION
**Reason for this PR**
As mentioned in #336 , on the *Publication Details* page there currently is no indicator as to whether or not a paper has been scaned for reuse. This can be seen on the current deployment of DoR (e.g. [here](https://www.reuse-dept.org/doi/10.1109/sp.2017.49)):

![grafik](https://user-images.githubusercontent.com/37844219/183906911-c6e2e944-9b10-4658-9e0d-9f0494292fdf.png)

**Changes in this PR**
This PR adds an indicator to the *Publication Details* page for when no data about reuse is available. The result can be seen here:
![grafik](https://user-images.githubusercontent.com/37844219/183907473-d6db3a8a-bb78-4a85-b217-915916d4f341.png)

Note that due to the way we record reuse, it is not possible at runtime to distinguish papers that have not been processed from papers that just don't reuse anything, but in fact have been processed. The indicator will be shown in both cases.
